### PR TITLE
Update boot32lb.asm - Replaced FreeDOS with SvarDOS in loading text string.

### DIFF
--- a/boot/boot32lb.asm
+++ b/boot/boot32lb.asm
@@ -413,7 +413,7 @@ no_incr_es:	pop	di
 
 ;-----------------------------------------------------------------------
 
-msg_LoadFreeDOS db "Loading FreeDOS ",0
+msg_LoadFreeDOS db "Loading SvarDOS ",0
 
        times 0x01ee-$+$$ db 0
 
@@ -426,3 +426,4 @@ filename	db "KERNEL  SYS"
 
 sign		dw 0, 0xAA55
 		; Win9x uses all 4 bytes as magic value here.
+


### PR DESCRIPTION

I simply changed the "Loading FreeDOS" to "Loading SvarDOS". Feel free to change it to whatever else you want to. This should hopefully close BUG #132 of SvarDOS.